### PR TITLE
Fix e2e test

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Download Go modules
         run: go mod download
 
-      - name: Build fetchr binary
+      - name: Build netkit binary
         run: make build
 
       - name: Run Go end-to-end tests

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -157,13 +157,18 @@ type netkitCmd struct {
 
 // startProxyServer starts the netkit proxy server with the given arguments
 func startProxyServer(t *testing.T, args ...string) *netkitCmd {
-	// Build binary path - we assume the binary is in the root directory
-	binaryPath := filepath.Join("..", "..", "netkit")
+	// Build binary path - we assume the binary is in the bin directory
+	binaryPath := filepath.Join("..", "..", "bin", "netkit")
 
 	// Check if binary exists
 	if _, err := os.Stat(binaryPath); os.IsNotExist(err) {
 		// Try to build it
 		t.Log("Netkit binary not found, building it")
+		// Ensure bin directory exists
+		binDir := filepath.Join("..", "..", "bin")
+		if err := os.MkdirAll(binDir, 0755); err != nil {
+			t.Fatalf("Failed to create bin directory: %v", err)
+		}
 		buildCmd := exec.Command("go", "build", "-o", binaryPath, "../../cmd/netkit")
 		if err := buildCmd.Run(); err != nil {
 			t.Fatalf("Failed to build netkit binary: %v", err)


### PR DESCRIPTION
- Updated e2e test to look for binary in bin/netkit instead of root
- Added bin directory creation in e2e test build fallback
- Fixed misleading comment in GitHub Actions workflow (fetchr -> netkit)

This ensures consistency with the Makefile build target which places the binary in bin/netkit, resolving CI failures where the binary couldn't be found in the expected location.

🤖 Generated with [Claude Code](https://claude.com/claude-code)