### PR TITLE
fix: serve built dashboard in e2e workflow

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -66,7 +66,7 @@ jobs:
 
       - name: Start netkit server for Playwright tests
         run: |
-          ./bin/netkit serve --port 8080 --admin-port 8081 --dashboard-port 3000 &
+          ./bin/netkit serve --port 8080 --admin-port 8081 --dashboard-port 3000 --dashboard-dir dashboard/out &
           echo $! > /tmp/netkit.pid
           # Wait for servers to be ready
           timeout 30 bash -c 'until curl -s http://localhost:8081/healthz > /dev/null; do sleep 1; done'


### PR DESCRIPTION
## Summary

- Serve the static dashboard build from `dashboard/out` when the E2E workflow starts netkit for Playwright.
- Keeps CI from testing the non-embedded fallback dashboard page after the dashboard build step.

## Root Cause

The workflow built the dashboard but started `./bin/netkit` without `--dashboard-dir`, so port 3000 served the fallback "Dashboard not embedded" page. Playwright then passed the title check but failed when looking for the real dashboard controls.

## Validation

- `CI=true npm run test:e2e` passed locally: 7 tests passed.
- `make e2e` passed locally.

Fixes #11.
Fixes #14.