### PR TITLE
Fix Docker dashboard embedding

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,9 @@
+.git
+.github
+bin
+coverage*.txt
+dashboard/.next
+dashboard/node_modules
+dashboard/playwright-report
+dashboard/test-results
+internal/dashboard/out

--- a/.github/workflows/release-on-tag.yml
+++ b/.github/workflows/release-on-tag.yml
@@ -235,6 +235,9 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
+      - name: Validate Docker dashboard image
+        run: make test-docker-dashboard
+
       - name: Log in to Docker Hub
         uses: docker/login-action@v3
         with:

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,18 +2,23 @@
 FROM node:20-alpine AS dashboard-builder
 
 WORKDIR /dashboard
+ARG NETKIT_DASHBOARD_BASE_PATH=""
+ENV NEXT_PUBLIC_NETKIT_BASE_PATH=${NETKIT_DASHBOARD_BASE_PATH}
+ENV NEXT_TELEMETRY_DISABLED=1
 
 # Copy dashboard files
 COPY dashboard/package*.json ./
-RUN npm install --legacy-peer-deps
+RUN npm ci --legacy-peer-deps
 
 COPY dashboard/ ./
-RUN npm run build
+RUN npm run build:static
+RUN test -s /dashboard/out/index.html
 
 # Go build stage
 FROM golang:1.24-alpine AS builder
 
 WORKDIR /build
+ARG NETKIT_DASHBOARD_BASE_PATH=""
 
 # Copy go mod files
 COPY go.mod go.sum ./
@@ -24,12 +29,34 @@ COPY . .
 
 # Copy built dashboard from previous stage to the location expected by embed directive
 COPY --from=dashboard-builder /dashboard/out ./internal/dashboard/out
+RUN test -s ./internal/dashboard/out/index.html
 
 # Build the binary with embedded dashboard
 RUN CGO_ENABLED=0 GOOS=linux go build -tags embed_dashboard -o netkit ./cmd/netkit
+RUN set -eu; \
+    dashboard_path="${NETKIT_DASHBOARD_BASE_PATH:-/}"; \
+    if [ "$dashboard_path" = "" ]; then dashboard_path="/"; fi; \
+    case "$dashboard_path" in */) ;; *) dashboard_path="$dashboard_path/";; esac; \
+    api_prefix="${dashboard_path%/}"; \
+    ./netkit serve --port 18080 --admin-port 18081 --dashboard --dashboard-port 13000 --dashboard-base-path "$api_prefix" --log-level error >/tmp/netkit.log 2>&1 & \
+    pid="$!"; \
+    trap 'kill "$pid" 2>/dev/null || true' EXIT; \
+    for i in $(seq 1 30); do \
+      if wget -q -O /tmp/dashboard.html "http://127.0.0.1:13000${dashboard_path}"; then \
+        break; \
+      fi; \
+      sleep 1; \
+    done; \
+    test -s /tmp/dashboard.html; \
+    ! grep -q "Dashboard not embedded" /tmp/dashboard.html; \
+    grep -q "HTTP Proxy Dashboard" /tmp/dashboard.html; \
+    wget -q -O /tmp/health.json "http://127.0.0.1:13000${api_prefix}/api/admin/healthz"; \
+    grep -q '"healthy"' /tmp/health.json
 
 # Runtime stage
 FROM alpine:latest
+ARG NETKIT_DASHBOARD_BASE_PATH=""
+ENV NETKIT_DASHBOARD_BASE_PATH=${NETKIT_DASHBOARD_BASE_PATH}
 
 RUN apk --no-cache add ca-certificates
 

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 .PHONY: build test lint clean coverage release version install check ci help all dev commit-feat commit-fix commit-refactor commit-perf commit-security
 .PHONY: build-dashboard test-dashboard lint-dashboard clean-dashboard install-dashboard install-backend dashboard-dev serve-dev build-all clean-all
 .PHONY: changelog changelog-update changelog-init install-changelog-tools release-patch release-minor release-major release-prerelease release-prerelease-next
-.PHONY: commit-docs commit-style commit-test commit-chore commit-breaking check-conventional-commits test-e2e test-e2e-ui test-e2e-headed
+.PHONY: commit-docs commit-style commit-test commit-chore commit-breaking check-conventional-commits test-e2e test-e2e-ui test-e2e-headed test-docker-dashboard
 
 # Build variables
 BINARY_NAME=netkit
@@ -41,6 +41,7 @@ help:
 	@echo "  test-e2e               - Run Playwright E2E tests (headless)"
 	@echo "  test-e2e-ui            - Run Playwright E2E tests with UI mode (interactive)"
 	@echo "  test-e2e-headed        - Run Playwright E2E tests in headed mode (watch browser)"
+	@echo "  test-docker-dashboard  - Build the Docker image and verify it serves the embedded dashboard"
 	@echo ""
 	@echo "Lint commands:"
 	@echo "  lint                   - Run golangci-lint for Go code"
@@ -253,6 +254,10 @@ test-e2e-headed:
 	fi
 	@echo "🎭 Running Playwright E2E tests in headed mode..."
 	@cd $(DASHBOARD_DIR) && npm run test:e2e:headed
+
+# Build the Docker image and ensure the embedded dashboard is served, not fallback HTML
+test-docker-dashboard:
+	@./scripts/validate-docker-dashboard.sh
 
 # Run end-to-end tests
 e2e:
@@ -731,4 +736,4 @@ release:
 	@$(MAKE) _do_release version=$(version)
 
 # Default target
-all: help 
+all: help

--- a/README.md
+++ b/README.md
@@ -80,16 +80,29 @@ Flags:
   --port int              Proxy server port (default 8080)
   --admin-port int        Admin server port (enables admin endpoints)
   --history-size int      Maximum requests to keep in history (default 1000)
+  --dashboard             Enable web dashboard (default true)
+  --dashboard-port int    Dashboard server port (default 3000)
+  --dashboard-base-path   Public dashboard URL prefix, for example /netkit
   --log-level string      Log level: debug, info, warn, error (default "info")
 ```
 
 ### Environment Variables
 
-Dashboard configuration (in `dashboard/.env.local`):
+The embedded production dashboard uses same-origin API routes by default:
+`/api/proxy` for proxied requests and `/api/admin/*` for health, history, and metrics.
+
+For standalone dashboard development, you can still point the browser at separate proxy/admin ports in `dashboard/.env.local`:
 ```bash
 NEXT_PUBLIC_PROXY_HOST=localhost
 NEXT_PUBLIC_PROXY_PORT=8080
 NEXT_PUBLIC_ADMIN_PORT=8081
+```
+
+For path-based reverse proxies, build and run with the same base path:
+
+```bash
+docker build --build-arg NETKIT_DASHBOARD_BASE_PATH=/netkit -t netkit .
+docker run -e NETKIT_DASHBOARD_BASE_PATH=/netkit -p 3000:3000 -p 8080:8080 -p 8081:8081 netkit
 ```
 
 ## Usage Examples

--- a/cmd/netkit/main.go
+++ b/cmd/netkit/main.go
@@ -39,18 +39,20 @@ func runServe() {
 	dashboard := flag.Bool("dashboard", true, "Enable web dashboard")
 	dashboardPort := flag.Int("dashboard-port", 3000, "Dashboard port")
 	dashboardDir := flag.String("dashboard-dir", "", "Directory containing dashboard build files (optional if embedded)")
+	dashboardBasePath := flag.String("dashboard-base-path", envOrDefault("NETKIT_DASHBOARD_BASE_PATH", ""), "Public dashboard URL prefix for path-based reverse proxies")
 	logLevel := flag.String("log-level", "info", "Logging level (debug, info, warn, error)")
 	flag.Parse()
 
 	// Create proxy configuration
 	config := &proxy.Config{
-		Port:          *port,
-		AdminPort:     *adminPort,
-		HistorySize:   *historySize,
-		Dashboard:     *dashboard,
-		DashboardPort: *dashboardPort,
-		DashboardDir:  *dashboardDir,
-		LogLevel:      *logLevel,
+		Port:              *port,
+		AdminPort:         *adminPort,
+		HistorySize:       *historySize,
+		Dashboard:         *dashboard,
+		DashboardPort:     *dashboardPort,
+		DashboardDir:      *dashboardDir,
+		DashboardBasePath: *dashboardBasePath,
+		LogLevel:          *logLevel,
 	}
 
 	// Create and start proxy server
@@ -70,6 +72,7 @@ func runServe() {
 		if config.Dashboard {
 			log.Printf("Dashboard will be available on port %d", config.DashboardPort)
 			log.Printf("Dashboard directory: %s", config.DashboardDir)
+			log.Printf("Dashboard base path: %s", config.DashboardBasePath)
 		}
 	}
 
@@ -94,4 +97,11 @@ func runServe() {
 	if err := proxyServer.Stop(); err != nil {
 		log.Printf("Error stopping proxy server: %v", err)
 	}
+}
+
+func envOrDefault(key, fallback string) string {
+	if value := os.Getenv(key); value != "" {
+		return value
+	}
+	return fallback
 }

--- a/dashboard/README.md
+++ b/dashboard/README.md
@@ -125,11 +125,14 @@ npm start
 Create a `.env.local` file in the dashboard directory:
 
 ```env
-NEXT_PUBLIC_API_URL=http://localhost:3001
 NEXT_PUBLIC_PROXY_HOST=localhost
 NEXT_PUBLIC_PROXY_PORT=8080
 NEXT_PUBLIC_ADMIN_PORT=8081
 ```
+
+When embedded in the Go binary, the dashboard defaults to same-origin API routes
+instead of browser-visible localhost ports. Use `NEXT_PUBLIC_NETKIT_BASE_PATH`
+at build time when the dashboard is served under a path prefix such as `/netkit`.
 
 ### Proxy Setup
 

--- a/dashboard/next.config.ts
+++ b/dashboard/next.config.ts
@@ -1,40 +1,34 @@
 import type { NextConfig } from "next";
 
+const normalizeBasePath = (value?: string): string => {
+  if (!value || value === "/") {
+    return "";
+  }
+
+  const withLeadingSlash = value.startsWith("/") ? value : `/${value}`;
+  return withLeadingSlash.replace(/\/+$/, "");
+};
+
+const basePath = normalizeBasePath(
+  process.env.NEXT_PUBLIC_NETKIT_BASE_PATH ||
+  process.env.NETKIT_DASHBOARD_BASE_PATH
+);
+
 const nextConfig: NextConfig = {
   // Enable static export for embedding
   output: 'export',
   trailingSlash: true,
   distDir: 'out',
+  ...(basePath ? { basePath, assetPrefix: basePath } : {}),
+  env: {
+    NEXT_PUBLIC_NETKIT_BASE_PATH: basePath,
+  },
   
-  // Disable all caching to ensure fresh data
   experimental: {
     staleTimes: {
       dynamic: 0,
       static: 0,
     },
-  },
-  
-  // Add headers to prevent caching
-  async headers() {
-    return [
-      {
-        source: '/:path*',
-        headers: [
-          {
-            key: 'Cache-Control',
-            value: 'no-cache, no-store, must-revalidate',
-          },
-          {
-            key: 'Pragma',
-            value: 'no-cache',
-          },
-          {
-            key: 'Expires',
-            value: '0',
-          },
-        ],
-      },
-    ];
   },
   
   // Configure static export

--- a/dashboard/src/app/globals.css
+++ b/dashboard/src/app/globals.css
@@ -45,6 +45,8 @@
 
 :root {
   --radius: 0.625rem;
+  --font-geist-sans: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  --font-geist-mono: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace;
   --background: oklch(1 0 0);
   --foreground: oklch(0.129 0.042 264.695);
   --card: oklch(1 0 0);

--- a/dashboard/src/app/layout.tsx
+++ b/dashboard/src/app/layout.tsx
@@ -1,22 +1,13 @@
 import type { Metadata } from "next";
-import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
 
-const geist = Geist({
-  variable: "--font-geist-sans",
-  subsets: ["latin"],
-});
-
-const geistMono = Geist_Mono({
-  variable: "--font-geist-mono",
-  subsets: ["latin"],
-});
+const basePath = process.env.NEXT_PUBLIC_NETKIT_BASE_PATH || "";
 
 export const metadata: Metadata = {
   title: "netkit - HTTP Requests Helper",
   description: "A powerful HTTP proxy and request capture tool with a modern web dashboard",
   icons: {
-    icon: "/favicon.ico",
+    icon: `${basePath}/favicon.ico`,
   },
 };
 
@@ -27,9 +18,7 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en">
-      <body
-        className={`${geist.variable} ${geistMono.variable} antialiased`}
-      >
+      <body className="antialiased">
         {children}
       </body>
     </html>

--- a/dashboard/src/components/Header.tsx
+++ b/dashboard/src/components/Header.tsx
@@ -13,6 +13,8 @@ import { cn } from '../lib/utils';
 export function Header() {
   const [proxyStatus, setProxyStatus] = useState<'checking' | 'online' | 'offline'>('checking');
   const pathname = usePathname();
+  const proxyAddress = apiService.getProxyDisplayAddress();
+  const adminAddress = apiService.getAdminDisplayAddress();
 
   useEffect(() => {
     const checkProxyStatus = async () => {
@@ -117,12 +119,12 @@ export function Header() {
                 <TooltipTrigger asChild>
                   <Badge variant="outline" className="text-xs">
                     <Globe className="h-3 w-3 mr-1" />
-                    localhost:8080
+                    {proxyAddress}
                   </Badge>
                 </TooltipTrigger>
                 <TooltipContent>
                   <p>Proxy Server Address</p>
-                  <p className="text-xs text-muted-foreground">Configure your HTTP client to use this proxy</p>
+                  <p className="text-xs text-muted-foreground">Configure your HTTP client to use this proxy when exposed</p>
                 </TooltipContent>
               </Tooltip>
             </TooltipProvider>
@@ -130,7 +132,7 @@ export function Header() {
               <Tooltip>
                 <TooltipTrigger asChild>
                   <Badge variant="outline" className="text-xs bg-blue-50">
-                    Admin: 8081
+                    {adminAddress}
                   </Badge>
                 </TooltipTrigger>
                 <TooltipContent>
@@ -178,4 +180,4 @@ export function Header() {
       </div>
     </header>
   );
-} 
+}

--- a/dashboard/src/services/api.ts
+++ b/dashboard/src/services/api.ts
@@ -42,17 +42,118 @@ export interface RequestStats {
   methods?: Record<string, number>;
 }
 
+type RuntimeNetkitConfig = {
+  basePath?: string;
+  proxyBaseUrl?: string;
+  adminBaseUrl?: string;
+};
+
+declare global {
+  interface Window {
+    __NETKIT_CONFIG__?: RuntimeNetkitConfig;
+  }
+}
+
+const normalizeBasePath = (value?: string): string => {
+  if (!value || value === '/') {
+    return '';
+  }
+
+  const withLeadingSlash = value.startsWith('/') ? value : `/${value}`;
+  return withLeadingSlash.replace(/\/+$/, '');
+};
+
+const joinUrl = (base: string, path: string): string => {
+  const normalizedBase = base.replace(/\/+$/, '');
+  const normalizedPath = path.startsWith('/') ? path : `/${path}`;
+  return `${normalizedBase}${normalizedPath}`;
+};
+
 class ApiService {
-  private baseUrl: string;
   private proxyHost: string;
   private proxyPort: number;
   private adminPort: number;
 
   constructor() {
-    this.baseUrl = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:3001';
     this.proxyHost = process.env.NEXT_PUBLIC_PROXY_HOST || 'localhost';
     this.proxyPort = parseInt(process.env.NEXT_PUBLIC_PROXY_PORT || '8080');
     this.adminPort = parseInt(process.env.NEXT_PUBLIC_ADMIN_PORT || '8081');
+  }
+
+  private getRuntimeConfig(): RuntimeNetkitConfig {
+    if (typeof window === 'undefined') {
+      return {};
+    }
+
+    return window.__NETKIT_CONFIG__ || {};
+  }
+
+  private getPublicBasePath(): string {
+    return normalizeBasePath(
+      this.getRuntimeConfig().basePath ||
+      process.env.NEXT_PUBLIC_NETKIT_BASE_PATH ||
+      process.env.NEXT_PUBLIC_BASE_PATH
+    );
+  }
+
+  private useLegacyPortUrls(): boolean {
+    return process.env.NODE_ENV === 'development' ||
+      Boolean(
+        process.env.NEXT_PUBLIC_PROXY_HOST ||
+        process.env.NEXT_PUBLIC_PROXY_PORT ||
+        process.env.NEXT_PUBLIC_ADMIN_PORT
+      );
+  }
+
+  private getProxyBaseUrl(): string {
+    const configuredProxyUrl =
+      this.getRuntimeConfig().proxyBaseUrl ||
+      process.env.NEXT_PUBLIC_NETKIT_PROXY_BASE_URL ||
+      process.env.NEXT_PUBLIC_PROXY_BASE_URL;
+
+    if (configuredProxyUrl) {
+      return configuredProxyUrl.replace(/\/+$/, '');
+    }
+
+    if (this.useLegacyPortUrls()) {
+      return `http://${this.proxyHost}:${this.proxyPort}`;
+    }
+
+    return joinUrl(this.getPublicBasePath(), '/api/proxy');
+  }
+
+  private getAdminBaseUrl(): string {
+    const configuredAdminUrl =
+      this.getRuntimeConfig().adminBaseUrl ||
+      process.env.NEXT_PUBLIC_NETKIT_ADMIN_BASE_URL ||
+      process.env.NEXT_PUBLIC_ADMIN_BASE_URL ||
+      process.env.NEXT_PUBLIC_API_URL;
+
+    if (configuredAdminUrl) {
+      return configuredAdminUrl.replace(/\/+$/, '');
+    }
+
+    if (this.useLegacyPortUrls()) {
+      return `http://${this.proxyHost}:${this.adminPort}`;
+    }
+
+    return joinUrl(this.getPublicBasePath(), '/api/admin');
+  }
+
+  getProxyDisplayAddress(): string {
+    if (this.useLegacyPortUrls()) {
+      return `${this.proxyHost}:${this.proxyPort}`;
+    }
+
+    return this.getProxyBaseUrl();
+  }
+
+  getAdminDisplayAddress(): string {
+    if (this.useLegacyPortUrls()) {
+      return `Admin: ${this.adminPort}`;
+    }
+
+    return 'Admin API';
   }
 
   // Add no-cache headers to prevent browser caching
@@ -110,10 +211,8 @@ class ApiService {
       };
 
       // Send request to the proxy server, which will forward it to the destination
-      // specified in the X-Fetchr-Destination header
-      const proxyUrl = `http://${this.proxyHost}:${this.proxyPort}`;
-      
-      const response = await fetch(proxyUrl, fetchOptions);
+      // specified in the X-Netkit-Destination header.
+      const response = await fetch(this.getProxyBaseUrl(), fetchOptions);
       
       const responseBody = await response.text();
       const endTime = Date.now();
@@ -146,7 +245,7 @@ class ApiService {
   // Get request history from the backend
   async getRequestHistory(): Promise<BackendRequestRecord[]> {
     try {
-      const url = this.addCacheBuster(`http://${this.proxyHost}:${this.adminPort}/requests`);
+      const url = this.addCacheBuster(joinUrl(this.getAdminBaseUrl(), '/requests'));
       const response = await fetch(url, {
         method: 'GET',
         headers: this.getDefaultHeaders(),
@@ -166,7 +265,7 @@ class ApiService {
   // Get request statistics from the backend
   async getRequestStats(): Promise<RequestStats | null> {
     try {
-      const url = this.addCacheBuster(`http://${this.proxyHost}:${this.adminPort}/requests/stats`);
+      const url = this.addCacheBuster(joinUrl(this.getAdminBaseUrl(), '/requests/stats'));
       const response = await fetch(url, {
         method: 'GET',
         headers: this.getDefaultHeaders(),
@@ -185,7 +284,7 @@ class ApiService {
   // Clear request history on the backend
   async clearRequestHistory(): Promise<boolean> {
     try {
-      const url = this.addCacheBuster(`http://${this.proxyHost}:${this.adminPort}/requests/clear`);
+      const url = this.addCacheBuster(joinUrl(this.getAdminBaseUrl(), '/requests/clear'));
       const response = await fetch(url, {
         method: 'POST',
         headers: {
@@ -204,7 +303,7 @@ class ApiService {
   // Health check for proxy (now on admin port)
   async checkProxyHealth(): Promise<boolean> {
     try {
-      const url = this.addCacheBuster(`http://${this.proxyHost}:${this.adminPort}/healthz`);
+      const url = this.addCacheBuster(joinUrl(this.getAdminBaseUrl(), '/healthz'));
       const response = await fetch(url, {
         method: 'GET',
         headers: this.getDefaultHeaders(),
@@ -217,4 +316,4 @@ class ApiService {
   }
 }
 
-export const apiService = new ApiService(); 
+export const apiService = new ApiService();

--- a/docs/INTERFACES.md
+++ b/docs/INTERFACES.md
@@ -138,6 +138,15 @@ NEXT_PUBLIC_PROXY_PORT=8080
 NEXT_PUBLIC_ADMIN_PORT=8081
 ```
 
+Embedded production dashboards default to same-origin API routes on the dashboard server:
+
+- `/api/proxy` forwards browser requests through the proxy using `X-Netkit-Destination`.
+- `/api/admin/*` mirrors the admin API for health, metrics, history, stats, and clearing history.
+
+For a path-based reverse proxy such as `/netkit`, build the static dashboard with
+`NETKIT_DASHBOARD_BASE_PATH=/netkit` and run `netkit serve --dashboard-base-path /netkit`
+or set the same value in the `NETKIT_DASHBOARD_BASE_PATH` environment variable.
+
 ### Development Setup
 
 ```bash
@@ -349,4 +358,4 @@ netkit cache stats --format json
 
 # Export cache contents
 netkit cache export --output cache-backup.json
-``` 
+```

--- a/internal/dashboard/dashboard.go
+++ b/internal/dashboard/dashboard.go
@@ -4,137 +4,20 @@ package dashboard
 
 import (
 	"embed"
-	"io"
 	"io/fs"
 	"net/http"
-	"path"
-	"strconv"
-	"strings"
 )
 
 //go:embed all:out
 var dashboardFiles embed.FS
 
 // Handler returns an http.Handler that serves the embedded dashboard files
-func Handler() http.Handler {
+func Handler(options ...Options) http.Handler {
 	// Get the embedded filesystem starting from the 'out' directory
 	dashboardFS, err := fs.Sub(dashboardFiles, "out")
 	if err != nil {
 		panic("failed to create dashboard filesystem: " + err.Error())
 	}
 
-	return &dashboardHandler{fs: dashboardFS}
-}
-
-type dashboardHandler struct {
-	fs fs.FS
-}
-
-func (h *dashboardHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	// Clean the path and remove leading slash
-	filePath := strings.TrimPrefix(path.Clean(r.URL.Path), "/")
-
-	// If the path is empty, serve index.html
-	if filePath == "" || filePath == "." {
-		filePath = "index.html"
-	}
-
-	// Check if file exists
-	file, err := h.fs.Open(filePath)
-	if err != nil {
-		// For SPA routing, serve index.html for non-existent files
-		// unless the request is for an asset (has file extension)
-		if !strings.Contains(filePath, ".") {
-			// First try appending /index.html for Next.js static export pages
-			indexPath := filePath + "/index.html"
-			file, err = h.fs.Open(indexPath)
-			if err != nil {
-				// Fall back to root index.html for client-side routing
-				filePath = "index.html"
-				file, err = h.fs.Open(filePath)
-				if err != nil {
-					http.NotFound(w, r)
-					return
-				}
-			} else {
-				filePath = indexPath
-			}
-		} else {
-			http.NotFound(w, r)
-			return
-		}
-	} else {
-		// Check if it's a directory
-		fileInfo, err := file.Stat()
-		if err == nil && fileInfo.IsDir() {
-			file.Close()
-			// Try to serve index.html from the directory
-			indexPath := filePath + "/index.html"
-			file, err = h.fs.Open(indexPath)
-			if err != nil {
-				// Fall back to root index.html for client-side routing
-				filePath = "index.html"
-				file, err = h.fs.Open(filePath)
-				if err != nil {
-					http.NotFound(w, r)
-					return
-				}
-			} else {
-				filePath = indexPath
-			}
-		}
-	}
-	defer file.Close()
-
-	// Set content type based on file extension
-	setContentType(w, filePath)
-
-	// Add no-cache headers for dashboard requests
-	w.Header().Set("Cache-Control", "no-cache, no-store, must-revalidate")
-	w.Header().Set("Pragma", "no-cache")
-	w.Header().Set("Expires", "0")
-
-	// Read file content and serve it
-	content, err := io.ReadAll(file)
-	if err != nil {
-		http.Error(w, "Error reading file", http.StatusInternalServerError)
-		return
-	}
-
-	// Serve the content
-	w.Header().Set("Content-Length", strconv.Itoa(len(content)))
-	w.WriteHeader(http.StatusOK)
-	w.Write(content)
-}
-
-func setContentType(w http.ResponseWriter, filePath string) {
-	ext := path.Ext(filePath)
-	switch ext {
-	case ".html":
-		w.Header().Set("Content-Type", "text/html; charset=utf-8")
-	case ".css":
-		w.Header().Set("Content-Type", "text/css; charset=utf-8")
-	case ".js":
-		w.Header().Set("Content-Type", "application/javascript; charset=utf-8")
-	case ".json":
-		w.Header().Set("Content-Type", "application/json; charset=utf-8")
-	case ".png":
-		w.Header().Set("Content-Type", "image/png")
-	case ".jpg", ".jpeg":
-		w.Header().Set("Content-Type", "image/jpeg")
-	case ".gif":
-		w.Header().Set("Content-Type", "image/gif")
-	case ".svg":
-		w.Header().Set("Content-Type", "image/svg+xml")
-	case ".ico":
-		w.Header().Set("Content-Type", "image/x-icon")
-	case ".woff":
-		w.Header().Set("Content-Type", "font/woff")
-	case ".woff2":
-		w.Header().Set("Content-Type", "font/woff2")
-	case ".ttf":
-		w.Header().Set("Content-Type", "font/ttf")
-	default:
-		w.Header().Set("Content-Type", "application/octet-stream")
-	}
+	return newHandler(dashboardFS, mergeOptions(options...))
 }

--- a/internal/dashboard/fallback.go
+++ b/internal/dashboard/fallback.go
@@ -7,7 +7,7 @@ import (
 )
 
 // Handler returns a fallback handler when dashboard is not embedded
-func Handler() http.Handler {
+func Handler(options ...Options) http.Handler {
 	return &fallbackHandler{}
 }
 

--- a/internal/dashboard/handler.go
+++ b/internal/dashboard/handler.go
@@ -1,0 +1,160 @@
+package dashboard
+
+import (
+	"encoding/json"
+	"io"
+	"io/fs"
+	"net/http"
+	"os"
+	"path"
+	"strconv"
+	"strings"
+)
+
+// Options configures the static dashboard shell served by netkit.
+type Options struct {
+	BasePath     string `json:"basePath,omitempty"`
+	ProxyBaseURL string `json:"proxyBaseUrl,omitempty"`
+	AdminBaseURL string `json:"adminBaseUrl,omitempty"`
+}
+
+// DirectoryHandler returns a dashboard handler backed by a static export directory.
+func DirectoryHandler(dir string, options ...Options) http.Handler {
+	return newHandler(os.DirFS(dir), mergeOptions(options...))
+}
+
+func newHandler(fsys fs.FS, options Options) http.Handler {
+	return &dashboardHandler{fs: fsys, options: options}
+}
+
+func mergeOptions(options ...Options) Options {
+	if len(options) == 0 {
+		return Options{}
+	}
+
+	return options[0]
+}
+
+type dashboardHandler struct {
+	fs      fs.FS
+	options Options
+}
+
+func (h *dashboardHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	filePath := strings.TrimPrefix(path.Clean(r.URL.Path), "/")
+
+	if filePath == "" || filePath == "." {
+		filePath = "index.html"
+	}
+
+	file, err := h.fs.Open(filePath)
+	if err != nil {
+		// For static Next exports, first try the route-specific index.html, then
+		// fall back to the app shell for client-side routing.
+		if !strings.Contains(filePath, ".") {
+			indexPath := filePath + "/index.html"
+			file, err = h.fs.Open(indexPath)
+			if err != nil {
+				filePath = "index.html"
+				file, err = h.fs.Open(filePath)
+				if err != nil {
+					http.NotFound(w, r)
+					return
+				}
+			} else {
+				filePath = indexPath
+			}
+		} else {
+			http.NotFound(w, r)
+			return
+		}
+	} else {
+		fileInfo, err := file.Stat()
+		if err == nil && fileInfo.IsDir() {
+			file.Close()
+			indexPath := filePath + "/index.html"
+			file, err = h.fs.Open(indexPath)
+			if err != nil {
+				filePath = "index.html"
+				file, err = h.fs.Open(filePath)
+				if err != nil {
+					http.NotFound(w, r)
+					return
+				}
+			} else {
+				filePath = indexPath
+			}
+		}
+	}
+	defer file.Close()
+
+	setContentType(w, filePath)
+
+	w.Header().Set("Cache-Control", "no-cache, no-store, must-revalidate")
+	w.Header().Set("Pragma", "no-cache")
+	w.Header().Set("Expires", "0")
+
+	content, err := io.ReadAll(file)
+	if err != nil {
+		http.Error(w, "Error reading file", http.StatusInternalServerError)
+		return
+	}
+	content = h.injectRuntimeConfig(content, filePath)
+
+	w.Header().Set("Content-Length", strconv.Itoa(len(content)))
+	w.WriteHeader(http.StatusOK)
+	if _, err := w.Write(content); err != nil {
+		return
+	}
+}
+
+func (h *dashboardHandler) injectRuntimeConfig(content []byte, filePath string) []byte {
+	if path.Ext(filePath) != ".html" {
+		return content
+	}
+
+	config, err := json.Marshal(h.options)
+	if err != nil {
+		return content
+	}
+
+	script := []byte(`<script>window.__NETKIT_CONFIG__=` + string(config) + `;</script>`)
+	headEnd := []byte("</head>")
+	if !strings.Contains(string(content), string(headEnd)) {
+		return append(script, content...)
+	}
+
+	return []byte(strings.Replace(string(content), string(headEnd), string(script)+string(headEnd), 1))
+}
+
+func setContentType(w http.ResponseWriter, filePath string) {
+	ext := path.Ext(filePath)
+	switch ext {
+	case ".html":
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	case ".css":
+		w.Header().Set("Content-Type", "text/css; charset=utf-8")
+	case ".js":
+		w.Header().Set("Content-Type", "application/javascript; charset=utf-8")
+	case ".json":
+		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+	case ".png":
+		w.Header().Set("Content-Type", "image/png")
+	case ".jpg", ".jpeg":
+		w.Header().Set("Content-Type", "image/jpeg")
+	case ".gif":
+		w.Header().Set("Content-Type", "image/gif")
+	case ".svg":
+		w.Header().Set("Content-Type", "image/svg+xml")
+	case ".ico":
+		w.Header().Set("Content-Type", "image/x-icon")
+	case ".woff":
+		w.Header().Set("Content-Type", "font/woff")
+	case ".woff2":
+		w.Header().Set("Content-Type", "font/woff2")
+	case ".ttf":
+		w.Header().Set("Content-Type", "font/ttf")
+	default:
+		w.Header().Set("Content-Type", "application/octet-stream")
+	}
+}

--- a/internal/dashboard/handler.go
+++ b/internal/dashboard/handler.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"io"
 	"io/fs"
+	"log"
 	"net/http"
 	"os"
 	"path"
@@ -71,7 +72,7 @@ func (h *dashboardHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	} else {
 		fileInfo, err := file.Stat()
 		if err == nil && fileInfo.IsDir() {
-			file.Close()
+			closeDashboardFile(file)
 			indexPath := filePath + "/index.html"
 			file, err = h.fs.Open(indexPath)
 			if err != nil {
@@ -86,7 +87,7 @@ func (h *dashboardHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			}
 		}
 	}
-	defer file.Close()
+	defer closeDashboardFile(file)
 
 	setContentType(w, filePath)
 
@@ -105,6 +106,12 @@ func (h *dashboardHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusOK)
 	if _, err := w.Write(content); err != nil {
 		return
+	}
+}
+
+func closeDashboardFile(file fs.File) {
+	if err := file.Close(); err != nil {
+		log.Printf("Error closing dashboard file: %v", err)
 	}
 }
 

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -12,6 +12,7 @@ import (
 	"net"
 	"net/http"
 	"net/url"
+	"strings"
 	"time"
 
 	"github.com/biancarosa/netkit/internal/dashboard"
@@ -19,13 +20,14 @@ import (
 
 // Config holds the proxy configuration
 type Config struct {
-	Port          int
-	AdminPort     int
-	LogLevel      string
-	HistorySize   int    // Maximum number of requests to keep in history
-	Dashboard     bool   // Enable dashboard serving
-	DashboardPort int    // Port for dashboard (separate from admin port)
-	DashboardDir  string // Directory containing dashboard build files
+	Port              int
+	AdminPort         int
+	LogLevel          string
+	HistorySize       int    // Maximum number of requests to keep in history
+	Dashboard         bool   // Enable dashboard serving
+	DashboardPort     int    // Port for dashboard (separate from admin port)
+	DashboardDir      string // Directory containing dashboard build files
+	DashboardBasePath string // Optional public URL prefix for path-based reverse proxies
 }
 
 // Proxy represents the HTTP proxy server
@@ -81,24 +83,113 @@ func New(config *Config) *Proxy {
 
 	// Initialize the dashboard server if dashboard is enabled
 	if config.Dashboard && config.DashboardPort > 0 {
-		dashboardMux := http.NewServeMux()
+		var dashboardHandler http.Handler
+		dashboardBasePath := normalizeDashboardBasePath(config.DashboardBasePath)
+		dashboardOptions := dashboard.Options{
+			BasePath:     dashboardBasePath,
+			ProxyBaseURL: joinDashboardPath(dashboardBasePath, "/api/proxy"),
+			AdminBaseURL: joinDashboardPath(dashboardBasePath, "/api/admin"),
+		}
 
 		// Serve static files from dashboard directory or embedded dashboard
 		if config.DashboardDir != "" {
-			fileServer := http.FileServer(http.Dir(config.DashboardDir))
-			dashboardMux.Handle("/", fileServer)
+			dashboardHandler = dashboard.DirectoryHandler(config.DashboardDir, dashboardOptions)
 		} else {
 			// Use embedded dashboard
-			dashboardMux.Handle("/", dashboard.Handler())
+			dashboardHandler = dashboard.Handler(dashboardOptions)
 		}
 
 		proxy.dashboardServer = &http.Server{
 			Addr:    fmt.Sprintf(":%d", config.DashboardPort),
-			Handler: dashboardMux,
+			Handler: proxy.dashboardRouter(dashboardHandler),
 		}
 	}
 
 	return proxy
+}
+
+func (p *Proxy) dashboardRouter(staticHandler http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		strippedPath := stripDashboardBasePath(r.URL.Path, p.config.DashboardBasePath)
+		routedRequest := cloneRequestWithPath(r, strippedPath)
+
+		switch {
+		case strippedPath == "/api/proxy" || strings.HasPrefix(strippedPath, "/api/proxy/"):
+			p.handleHTTP(w, routedRequest)
+		case strippedPath == "/api/admin/healthz":
+			p.handleHealth(w, routedRequest)
+		case strippedPath == "/api/admin/metrics":
+			p.handleMetrics(w, routedRequest)
+		case strippedPath == "/api/admin/requests":
+			p.handleRequestHistory(w, routedRequest)
+		case strippedPath == "/api/admin/requests/stats":
+			p.handleRequestStats(w, routedRequest)
+		case strippedPath == "/api/admin/requests/clear":
+			p.handleClearHistory(w, routedRequest)
+		default:
+			staticHandler.ServeHTTP(w, routedRequest)
+		}
+	})
+}
+
+func cloneRequestWithPath(r *http.Request, path string) *http.Request {
+	clone := new(http.Request)
+	*clone = *r
+	urlCopy := *r.URL
+	urlCopy.Path = path
+	urlCopy.RawPath = ""
+	clone.URL = &urlCopy
+	return clone
+}
+
+func stripDashboardBasePath(requestPath, basePath string) string {
+	basePath = normalizeDashboardBasePath(basePath)
+	if basePath == "" {
+		return requestPath
+	}
+
+	if requestPath == basePath {
+		return "/"
+	}
+
+	if strings.HasPrefix(requestPath, basePath+"/") {
+		stripped := strings.TrimPrefix(requestPath, basePath)
+		if stripped == "" {
+			return "/"
+		}
+		return stripped
+	}
+
+	return requestPath
+}
+
+func normalizeDashboardBasePath(basePath string) string {
+	basePath = strings.TrimSpace(basePath)
+	if basePath == "" || basePath == "/" {
+		return ""
+	}
+
+	if !strings.HasPrefix(basePath, "/") {
+		basePath = "/" + basePath
+	}
+
+	return strings.TrimRight(basePath, "/")
+}
+
+func joinDashboardPath(basePath, routePath string) string {
+	basePath = normalizeDashboardBasePath(basePath)
+	if routePath == "" || routePath == "/" {
+		if basePath == "" {
+			return "/"
+		}
+		return basePath
+	}
+
+	if !strings.HasPrefix(routePath, "/") {
+		routePath = "/" + routePath
+	}
+
+	return basePath + routePath
 }
 
 // ServeHTTP implements the http.Handler interface for the proxy

--- a/scripts/validate-docker-dashboard.sh
+++ b/scripts/validate-docker-dashboard.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env sh
+set -eu
+
+image="${NETKIT_DOCKER_IMAGE:-netkit:dashboard-validation}"
+container="${NETKIT_DOCKER_CONTAINER:-netkit-dashboard-validation-$$}"
+proxy_port="${NETKIT_DOCKER_PROXY_PORT:-18080}"
+admin_port="${NETKIT_DOCKER_ADMIN_PORT:-18081}"
+dashboard_port="${NETKIT_DOCKER_DASHBOARD_PORT:-13000}"
+dashboard_path="${NETKIT_DASHBOARD_BASE_PATH:-/}"
+
+if [ "$dashboard_path" = "" ]; then
+  dashboard_path="/"
+fi
+
+case "$dashboard_path" in
+  */) ;;
+  *) dashboard_path="${dashboard_path}/" ;;
+esac
+
+api_prefix="${dashboard_path%/}"
+dashboard_url="http://127.0.0.1:${dashboard_port}${dashboard_path}"
+health_url="http://127.0.0.1:${dashboard_port}${api_prefix}/api/admin/healthz"
+tmp_dashboard="$(mktemp)"
+tmp_health="$(mktemp)"
+
+cleanup() {
+  rm -f "$tmp_dashboard" "$tmp_health"
+  docker rm -f "$container" >/dev/null 2>&1 || true
+}
+trap cleanup EXIT INT TERM
+
+if [ "${NETKIT_DOCKER_SKIP_BUILD:-}" != "1" ]; then
+  docker build \
+    --build-arg "NETKIT_DASHBOARD_BASE_PATH=${NETKIT_DASHBOARD_BASE_PATH:-}" \
+    -t "$image" .
+fi
+
+docker run -d \
+  --name "$container" \
+  -p "127.0.0.1:${proxy_port}:8080" \
+  -p "127.0.0.1:${admin_port}:8081" \
+  -p "127.0.0.1:${dashboard_port}:3000" \
+  "$image" >/dev/null
+
+for _ in 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30; do
+  if curl -fsS "$dashboard_url" > "$tmp_dashboard"; then
+    break
+  fi
+  sleep 1
+done
+
+if [ ! -s "$tmp_dashboard" ]; then
+  echo "Dashboard did not respond at ${dashboard_url}" >&2
+  docker logs "$container" >&2 || true
+  exit 1
+fi
+
+if grep -q "Dashboard not embedded" "$tmp_dashboard"; then
+  echo "Docker image served the fallback dashboard instead of the embedded dashboard" >&2
+  exit 1
+fi
+
+if ! grep -q "HTTP Proxy Dashboard" "$tmp_dashboard"; then
+  echo "Docker image did not serve the expected dashboard HTML" >&2
+  exit 1
+fi
+
+curl -fsS "$health_url" > "$tmp_health"
+if ! grep -q '"healthy"' "$tmp_health"; then
+  echo "Dashboard same-origin admin API did not return healthy status" >&2
+  exit 1
+fi
+
+echo "Docker dashboard validation passed for ${image}"


### PR DESCRIPTION
## Summary

- Build the Next static dashboard inside the Docker image and embed it into the Go binary before compiling with `embed_dashboard`.
- Serve embedded dashboard API calls through same-origin `/api/proxy` and `/api/admin/*` routes, with `NETKIT_DASHBOARD_BASE_PATH` / `--dashboard-base-path` support for path-based reverse proxies such as `/netkit`.
- Add Docker dashboard validation so fallback HTML fails the image build and release flow.
- Remove the dashboard's build-time Google font dependency so static export is reproducible without external font fetches.

## Root Cause

The published Docker image could run a binary that served the fallback dashboard, and the frontend assumed browser-visible `localhost:8080/8081` API URLs. That broke embedded Docker deployments and path-based reverse proxy setups.

## Validation

- `go test ./...`
- `cd dashboard && npm run build:static`
- `make test-docker-dashboard`
- `NETKIT_DASHBOARD_BASE_PATH=/netkit NETKIT_DOCKER_IMAGE=netkit:dashboard-validation-netkit NETKIT_DOCKER_DASHBOARD_PORT=13001 NETKIT_DOCKER_PROXY_PORT=18082 NETKIT_DOCKER_ADMIN_PORT=18083 make test-docker-dashboard`